### PR TITLE
Add in-memory Job repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ Date: Mon, 26 Jun 2017 10:49:31 GMT
 
 ## Testing
 
-Tests can be run via `python -m pytest middleware`.
+Tests can be run via `python -m pytest`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This code is tested on `python 3.6` and all dependencies can be installed via `p
 pip install -r requirements.txt
 ```
 
-At present this app uses a `secrets.py` file to store login details. For obvious reasons this is not committed with the rest of the code, but can be created locally. The code expects a `secrets.py` file placed in the root of the directory with the following variables:
+At present this app uses a `secrets.py` file to store login details. This file must be present in the `instance` directory of the package. This directory is
+excluded from source control and contains instance-specific data. The code expects an `instance/secrets.py` file  with the following variables:
 
 ```
 USERNAME = "<a username>"
@@ -76,4 +77,4 @@ Date: Mon, 26 Jun 2017 10:49:31 GMT
 
 ## Testing
 
-Tests can be run via `pytest`.
+Tests can be run via `python -m pytest middleware`.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ This code is tested on `python 3.6` and all dependencies can be installed via `p
 pip install -r requirements.txt
 ```
 
-At present this app uses a `secrets.py` file to store login details. This file must be present in the `instance` directory of the package. This directory is
-excluded from source control and contains instance-specific data. The code expects an `instance/secrets.py` file  with the following variables:
+At present this app uses a `secrets.py` file to store login details. For obvious reasons this is not committed with the rest of the code, but can be created locally. The code expects a `secrets.py` file placed in the root of the directory with the following variables:
 
 ```
 USERNAME = "<a username>"

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -19,9 +19,6 @@ class JobRepositoryMemory():
             return None
 
     def get_by_id(self, job_id):
-        # Note: We could skip the whole if..else check for the existence of
-        # job_id as a key as the dictionary.get() method returns None if the
-        # key does not exist.
         if self.exists(job_id):
             return self._jobs.get(job_id)
         else:

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -20,3 +20,12 @@ class JobRepositoryMemory():
             return self._jobs[job_id]
         else:
             return None
+
+    def update_job(self, job):
+        job_id = job["id"]
+        if(job_id in self._jobs):
+            # Replace job if already in job list
+            self._jobs[job_id] = job
+            return job
+        else:
+            return None

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -6,12 +6,15 @@ class JobRepositoryMemory():
     def __init__(self):
         self._jobs = {}
 
+    def exists(self, job_id):
+        return (job_id in self._jobs)
+
     def create(self, job):
         job_id = job["id"]
-        if(job_id not in self._jobs):
+        if(not self.exists(job_id)):
             # Add job if it is not already in job list
             self._jobs[job_id] = job
-            return job
+            return self.get_by_id(job_id)
         else:
             return None
 
@@ -19,23 +22,23 @@ class JobRepositoryMemory():
         # Note: We could skip the whole if..else check for the existence of
         # job_id as a key as the dictionary.get() method returns None if the
         # key does not exist.
-        if(job_id in self._jobs):
+        if(self.exists(job_id)):
             return self._jobs.get(job_id)
         else:
             return None
 
     def update(self, job):
         job_id = job["id"]
-        if(job_id in self._jobs):
+        if(self.exists(job_id)):
             # Replace job if already in job list
             self._jobs[job_id] = job
-            return job
+            return self.get_by_id(job_id)
         else:
             return None
 
     def delete(self, job):
         job_id = job["id"]
-        if(job_id in self._jobs):
+        if(self.exists(job_id)):
             # If job exists, remove job from dictionary and return removed job
             return self._jobs.pop(job_id)
         else:

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -1,0 +1,22 @@
+
+
+class JobRepositoryMemory():
+    '''Job service backed by an in-memory array for job storage. Used for
+    testing'''
+    def __init__(self):
+        self._jobs = {}
+
+    def create(self, job):
+        job_id = job["id"]
+        if(job_id not in self._jobs):
+            # Add job if it is not already in job list
+            self._jobs[job_id] = job
+            return job
+        else:
+            return None
+
+    def get_by_id(self, job_id):
+        if(job_id in self._jobs):
+            return self._jobs[job_id]
+        else:
+            return None

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -39,6 +39,7 @@ class JobRepositoryMemory():
     def delete(self, job_id):
         if(self.exists(job_id)):
             # If job exists, remove job from dictionary and return removed job
-            return self._jobs.pop(job_id)
+            self._jobs.pop(job_id)
+            return None
         else:
             return None

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -11,7 +11,7 @@ class JobRepositoryMemory():
 
     def create(self, job):
         job_id = job["id"]
-        if(not self.exists(job_id)):
+        if not self.exists(job_id):
             # Add job if it is not already in job list
             self._jobs[job_id] = job
             return self.get_by_id(job_id)
@@ -22,14 +22,14 @@ class JobRepositoryMemory():
         # Note: We could skip the whole if..else check for the existence of
         # job_id as a key as the dictionary.get() method returns None if the
         # key does not exist.
-        if(self.exists(job_id)):
+        if self.exists(job_id):
             return self._jobs.get(job_id)
         else:
             return None
 
     def update(self, job):
         job_id = job["id"]
-        if(self.exists(job_id)):
+        if self.exists(job_id):
             # Replace job if already in job list
             self._jobs[job_id] = job
             return self.get_by_id(job_id)
@@ -37,7 +37,7 @@ class JobRepositoryMemory():
             return None
 
     def delete(self, job_id):
-        if(self.exists(job_id)):
+        if self.exists(job_id):
             # If job exists, remove job from dictionary and return removed job
             self._jobs.pop(job_id)
             return None

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -16,8 +16,11 @@ class JobRepositoryMemory():
             return None
 
     def get_by_id(self, job_id):
+        # Note: We could skip the whole if..else check for the existence of
+        # job_id as a key as the dictionary.get() method returns None if the
+        # key does not exist.
         if(job_id in self._jobs):
-            return self._jobs[job_id]
+            return self._jobs.get(job_id)
         else:
             return None
 

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -36,8 +36,7 @@ class JobRepositoryMemory():
         else:
             return None
 
-    def delete(self, job):
-        job_id = job["id"]
+    def delete(self, job_id):
         if(self.exists(job_id)):
             # If job exists, remove job from dictionary and return removed job
             return self._jobs.pop(job_id)

--- a/middleware/job/inmemory.py
+++ b/middleware/job/inmemory.py
@@ -24,11 +24,19 @@ class JobRepositoryMemory():
         else:
             return None
 
-    def update_job(self, job):
+    def update(self, job):
         job_id = job["id"]
         if(job_id in self._jobs):
             # Replace job if already in job list
             self._jobs[job_id] = job
             return job
+        else:
+            return None
+
+    def delete(self, job):
+        job_id = job["id"]
+        if(job_id in self._jobs):
+            # If job exists, remove job from dictionary and return removed job
+            return self._jobs.pop(job_id)
         else:
             return None

--- a/middleware/views.py
+++ b/middleware/views.py
@@ -1,7 +1,7 @@
 from flask import Flask, jsonify, abort, request, make_response
 from flask_httpauth import HTTPBasicAuth
 from .ssh import ssh
-from secrets import *
+from instance.secrets import *
 
 app = Flask(__name__)
 

--- a/middleware/views.py
+++ b/middleware/views.py
@@ -1,7 +1,7 @@
 from flask import Flask, jsonify, abort, request, make_response
 from flask_httpauth import HTTPBasicAuth
 from .ssh import ssh
-from instance.secrets import *
+from secrets import *
 
 app = Flask(__name__)
 

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -14,14 +14,29 @@ class TestJobRepositoryMemory(object):
         job = {"id": job_id,
                "parameters": {"height": 3, "width": 4, "depth": 5}}
         repo._jobs[job_id] = job
-        job_ret = repo.get_by_id(job_id)
-        assert(job_ret == job)
+        job_returned = repo.get_by_id(job_id)
+        assert(job_returned == job)
 
     def test_create_job(self):
         repo = JobRepositoryMemory()
         job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
         job = {"id": job_id,
                "parameters": {"height": 3, "width": 4, "depth": 5}}
-        repo.create(job)
-        job_ret = repo._jobs[job_id]
-        assert(job_ret == job)
+        job_returned = repo.create(job)
+        job_stored = repo._jobs[job_id]
+        assert(job_returned == job)
+        assert(job_stored == job)
+
+    def test_update_job(self):
+        # Test that update replaces job object in entirety
+        repo = JobRepositoryMemory()
+        job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job_initial = {"id": job_id, "parameters": {"height": 3, "width": 4,
+                       "depth": 5}}
+        job_updated = {"id": job_id, "purple": {"circle": "street",
+                       "triangle": "road", "square": "avenue"}}
+        repo._jobs[job_id] = job_initial
+        job_returned = repo.update_job(job_updated)
+        job_stored = repo._jobs[job_id]
+        assert(job_returned == job_updated)
+        assert(job_stored == job_updated)

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -68,7 +68,8 @@ class TestJobRepositoryMemory(object):
     def test_update_nonexistent_job_returns_none(self):
         repo = JobRepositoryMemory()
         job_id_initial = "d769843b-6f37-4939-96c7-c382c3e74b46"
-        job_initial = {"id": job_id_initial, "parameters": {"height": 3, "width": 4, "depth": 5}}
+        job_initial = {"id": job_id_initial, "parameters": {"height": 3,
+                       "width": 4, "depth": 5}}
         job_id_updated = "ad460823-370c-48dd-a09f-a7564bb458f1"
         job_updated = {"id": job_id_updated, "purple": {"circle": "street",
                        "triangle": "road", "square": "avenue"}}

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -17,7 +17,7 @@ class TestJobRepositoryMemory(object):
                "parameters": {"height": 3, "width": 4, "depth": 5}}
         repo._jobs[job_id] = job
         job_returned = repo.exists(job_id)
-        assert(job_returned is True)
+        assert job_returned is True
 
     def test_exists_for_nonexistent_job_returns_false(self):
         repo = JobRepositoryMemory()
@@ -27,7 +27,7 @@ class TestJobRepositoryMemory(object):
         repo._jobs[store_id] = job
         fetch_id = "ad460823-370c-48dd-a09f-a7564bb458f1"
         job_returned = repo.exists(fetch_id)
-        assert(job_returned is False)
+        assert job_returned is False
 
     def test_get_existing_job_by_id_returns_job(self):
         repo = JobRepositoryMemory()
@@ -36,7 +36,7 @@ class TestJobRepositoryMemory(object):
                "parameters": {"height": 3, "width": 4, "depth": 5}}
         repo._jobs[job_id] = job
         job_returned = repo.get_by_id(job_id)
-        assert(job_returned == job)
+        assert job_returned == job
 
     def test_get_nonexistent_job_by_id_returns_none(self):
         repo = JobRepositoryMemory()
@@ -46,7 +46,7 @@ class TestJobRepositoryMemory(object):
         repo._jobs[store_id] = job
         fetch_id = "ad460823-370c-48dd-a09f-a7564bb458f1"
         job_returned = repo.get_by_id(fetch_id)
-        assert(job_returned is None)
+        assert job_returned is None
 
     def test_create_nonexistent_job_creates_job(self):
         repo = JobRepositoryMemory()
@@ -55,8 +55,8 @@ class TestJobRepositoryMemory(object):
                "parameters": {"height": 3, "width": 4, "depth": 5}}
         job_returned = repo.create(job)
         job_stored = repo._jobs.get(job_id)
-        assert(job_returned == job)
-        assert(job_stored == job)
+        assert job_returned == job
+        assert job_stored == job
 
     def test_create_existing_job_returns_none(self):
         repo = JobRepositoryMemory()
@@ -68,8 +68,8 @@ class TestJobRepositoryMemory(object):
         repo._jobs[job_id] = job_initial
         job_returned = repo.create(job_updated)
         job_stored = repo._jobs.get(job_id)
-        assert(job_returned is None)
-        assert(job_stored is job_initial)
+        assert job_returned is None
+        assert job_stored is job_initial
 
     def test_update_replaces_existing_job_completely(self):
         repo = JobRepositoryMemory()
@@ -81,8 +81,8 @@ class TestJobRepositoryMemory(object):
         repo._jobs[job_id] = job_initial
         job_returned = repo.update(job_updated)
         job_stored = repo._jobs.get(job_id)
-        assert(job_returned == job_updated)
-        assert(job_stored == job_updated)
+        assert job_returned == job_updated
+        assert job_stored == job_updated
 
     def test_update_nonexistent_job_returns_none(self):
         repo = JobRepositoryMemory()
@@ -96,9 +96,9 @@ class TestJobRepositoryMemory(object):
         job_returned = repo.update(job_updated)
         job_stored_updated = repo._jobs.get(job_id_updated)
         job_stored_initial = repo._jobs.get(job_id_initial)
-        assert(job_returned is None)
-        assert(job_stored_updated is None)
-        assert(job_stored_initial == job_initial)
+        assert job_returned is None
+        assert job_stored_updated is None
+        assert job_stored_initial == job_initial
 
     def test_delete_existing_job_deletes_job(self):
         repo = JobRepositoryMemory()
@@ -108,8 +108,8 @@ class TestJobRepositoryMemory(object):
         repo._jobs[job_id] = job
         job_returned = repo.delete(job_id)
         job_stored = repo._jobs.get(job_id)
-        assert(job_returned is None)
-        assert(job_stored is None)
+        assert job_returned is None
+        assert job_stored is None
 
     def test_delete_nonexistent_job_returns_none(self):
         repo = JobRepositoryMemory()
@@ -120,5 +120,5 @@ class TestJobRepositoryMemory(object):
         repo._jobs[job_id_initial] = job_initial
         job_returned = repo.delete(job_id_updated)
         job_stored = repo._jobs.get(job_id_initial)
-        assert(job_returned is None)
-        assert(job_stored == job_initial)
+        assert job_returned is None
+        assert job_stored == job_initial

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -60,7 +60,7 @@ class TestJobRepositoryMemory(object):
         job_updated = {"id": job_id, "purple": {"circle": "street",
                        "triangle": "road", "square": "avenue"}}
         repo._jobs[job_id] = job_initial
-        job_returned = repo.update_job(job_updated)
+        job_returned = repo.update(job_updated)
         job_stored = repo._jobs.get(job_id)
         assert(job_returned == job_updated)
         assert(job_stored == job_updated)
@@ -74,9 +74,34 @@ class TestJobRepositoryMemory(object):
         job_updated = {"id": job_id_updated, "purple": {"circle": "street",
                        "triangle": "road", "square": "avenue"}}
         repo._jobs[job_id_initial] = job_initial
-        job_returned = repo.update_job(job_updated)
+        job_returned = repo.update(job_updated)
         job_stored_updated = repo._jobs.get(job_id_updated)
         job_stored_initial = repo._jobs.get(job_id_initial)
         assert(job_returned is None)
         assert(job_stored_updated is None)
         assert(job_stored_initial == job_initial)
+
+    def test_delete_existing_job_deletes_job(self):
+        repo = JobRepositoryMemory()
+        job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job = {"id": job_id,
+               "parameters": {"height": 3, "width": 4, "depth": 5}}
+        repo._jobs[job_id] = job
+        job_returned = repo.delete(job)
+        job_stored = repo._jobs.get(job_id)
+        assert(job_returned == job)
+        assert(job_stored is None)
+
+    def test_delete_nonexistent_job_returns_none(self):
+        repo = JobRepositoryMemory()
+        job_id_initial = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job_initial = {"id": job_id_initial, "parameters": {"height": 3,
+                       "width": 4, "depth": 5}}
+        job_id_updated = "ad460823-370c-48dd-a09f-a7564bb458f1"
+        job_updated = {"id": job_id_updated, "purple": {"circle": "street",
+                       "triangle": "road", "square": "avenue"}}
+        repo._jobs[job_id_initial] = job_initial
+        job_returned = repo.delete(job_updated)
+        job_stored = repo._jobs.get(job_id_initial)
+        assert(job_returned is None)
+        assert(job_stored == job_initial)

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -2,13 +2,15 @@ from middleware.job.inmemory import JobRepositoryMemory
 
 
 class TestJobRepositoryMemory(object):
+    # Notes: We use dictionary.get(key) rather than dictionary[key] to ensure
+    # we get None rather than KeyError if the key does not exist
 
     def test_new_repo_has_no_jobs(self):
         repo = JobRepositoryMemory()
         # New repository onject should have empty jobs list
         assert len(repo._jobs) == 0
 
-    def test_get_by_id(self):
+    def test_get_existing_job_by_id_returns_job(self):
         repo = JobRepositoryMemory()
         job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
         job = {"id": job_id,
@@ -17,18 +19,40 @@ class TestJobRepositoryMemory(object):
         job_returned = repo.get_by_id(job_id)
         assert(job_returned == job)
 
-    def test_create_job(self):
+    def test_get_nonexistent_job_by_id_returns_none(self):
+        repo = JobRepositoryMemory()
+        store_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job = {"id": store_id,
+               "parameters": {"height": 3, "width": 4, "depth": 5}}
+        repo._jobs[store_id] = job
+        fetch_id = "ad460823-370c-48dd-a09f-a7564bb458f1"
+        job_returned = repo.get_by_id(fetch_id)
+        assert(job_returned is None)
+
+    def test_create_nonexistent_job_creates_job(self):
         repo = JobRepositoryMemory()
         job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
         job = {"id": job_id,
                "parameters": {"height": 3, "width": 4, "depth": 5}}
         job_returned = repo.create(job)
-        job_stored = repo._jobs[job_id]
+        job_stored = repo._jobs.get(job_id)
         assert(job_returned == job)
         assert(job_stored == job)
 
-    def test_update_job(self):
-        # Test that update replaces job object in entirety
+    def test_create_existing_job_returns_none(self):
+        repo = JobRepositoryMemory()
+        job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job_initial = {"id": job_id, "parameters": {"height": 3, "width": 4,
+                       "depth": 5}}
+        job_updated = {"id": job_id, "purple": {"circle": "street",
+                       "triangle": "road", "square": "avenue"}}
+        repo._jobs[job_id] = job_initial
+        job_returned = repo.create(job_updated)
+        job_stored = repo._jobs.get(job_id)
+        assert(job_returned is None)
+        assert(job_stored is job_initial)
+
+    def test_update_replaces_existing_job_completely(self):
         repo = JobRepositoryMemory()
         job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
         job_initial = {"id": job_id, "parameters": {"height": 3, "width": 4,
@@ -37,6 +61,21 @@ class TestJobRepositoryMemory(object):
                        "triangle": "road", "square": "avenue"}}
         repo._jobs[job_id] = job_initial
         job_returned = repo.update_job(job_updated)
-        job_stored = repo._jobs[job_id]
+        job_stored = repo._jobs.get(job_id)
         assert(job_returned == job_updated)
         assert(job_stored == job_updated)
+
+    def test_update_nonexistent_job_returns_none(self):
+        repo = JobRepositoryMemory()
+        job_id_initial = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job_initial = {"id": job_id_initial, "parameters": {"height": 3, "width": 4, "depth": 5}}
+        job_id_updated = "ad460823-370c-48dd-a09f-a7564bb458f1"
+        job_updated = {"id": job_id_updated, "purple": {"circle": "street",
+                       "triangle": "road", "square": "avenue"}}
+        repo._jobs[job_id_initial] = job_initial
+        job_returned = repo.update_job(job_updated)
+        job_stored_updated = repo._jobs.get(job_id_updated)
+        job_stored_initial = repo._jobs.get(job_id_initial)
+        assert(job_returned is None)
+        assert(job_stored_updated is None)
+        assert(job_stored_initial == job_initial)

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -106,7 +106,7 @@ class TestJobRepositoryMemory(object):
         job = {"id": job_id,
                "parameters": {"height": 3, "width": 4, "depth": 5}}
         repo._jobs[job_id] = job
-        job_returned = repo.delete(job)
+        job_returned = repo.delete(job_id)
         job_stored = repo._jobs.get(job_id)
         assert(job_returned == job)
         assert(job_stored is None)
@@ -117,10 +117,8 @@ class TestJobRepositoryMemory(object):
         job_initial = {"id": job_id_initial, "parameters": {"height": 3,
                        "width": 4, "depth": 5}}
         job_id_updated = "ad460823-370c-48dd-a09f-a7564bb458f1"
-        job_updated = {"id": job_id_updated, "purple": {"circle": "street",
-                       "triangle": "road", "square": "avenue"}}
         repo._jobs[job_id_initial] = job_initial
-        job_returned = repo.delete(job_updated)
+        job_returned = repo.delete(job_id_updated)
         job_stored = repo._jobs.get(job_id_initial)
         assert(job_returned is None)
         assert(job_stored == job_initial)

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -10,6 +10,25 @@ class TestJobRepositoryMemory(object):
         # New repository onject should have empty jobs list
         assert len(repo._jobs) == 0
 
+    def test_exists_for_existing_job_returns_true(self):
+        repo = JobRepositoryMemory()
+        job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job = {"id": job_id,
+               "parameters": {"height": 3, "width": 4, "depth": 5}}
+        repo._jobs[job_id] = job
+        job_returned = repo.exists(job_id)
+        assert(job_returned is True)
+
+    def test_exists_for_nonexistent_job_returns_false(self):
+        repo = JobRepositoryMemory()
+        store_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job = {"id": store_id,
+               "parameters": {"height": 3, "width": 4, "depth": 5}}
+        repo._jobs[store_id] = job
+        fetch_id = "ad460823-370c-48dd-a09f-a7564bb458f1"
+        job_returned = repo.exists(fetch_id)
+        assert(job_returned is False)
+
     def test_get_existing_job_by_id_returns_job(self):
         repo = JobRepositoryMemory()
         job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -1,0 +1,27 @@
+from middleware.job.inmemory import JobRepositoryMemory
+
+
+class TestJobRepositoryMemory(object):
+
+    def test_new_repo_has_no_jobs(self):
+        repo = JobRepositoryMemory()
+        # New repository onject should have empty jobs list
+        assert len(repo._jobs) == 0
+
+    def test_get_by_id(self):
+        repo = JobRepositoryMemory()
+        job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job = {"id": job_id,
+               "parameters": {"height": 3, "width": 4, "depth": 5}}
+        repo._jobs[job_id] = job
+        job_ret = repo.get_by_id(job_id)
+        assert(job_ret == job)
+
+    def test_create_job(self):
+        repo = JobRepositoryMemory()
+        job_id = "d769843b-6f37-4939-96c7-c382c3e74b46"
+        job = {"id": job_id,
+               "parameters": {"height": 3, "width": 4, "depth": 5}}
+        repo.create(job)
+        job_ret = repo._jobs[job_id]
+        assert(job_ret == job)

--- a/tests/job/test_inmemory.py
+++ b/tests/job/test_inmemory.py
@@ -108,7 +108,7 @@ class TestJobRepositoryMemory(object):
         repo._jobs[job_id] = job
         job_returned = repo.delete(job_id)
         job_stored = repo._jobs.get(job_id)
-        assert(job_returned == job)
+        assert(job_returned is None)
         assert(job_stored is None)
 
     def test_delete_nonexistent_job_returns_none(self):


### PR DESCRIPTION
Provides an in-memory Job repository to support testing and initial dummy standalone adapter. Connects to #7.

## Implementation
- `exists(job_id)`: Returns `True` if job with ID in repo. Otherwise returns `False`
- `create(job):` If job with same ID exists in repo, do nothing and return `None`. Otherwise, store job and return stored job.
- `get_by_id(job_id)`: Return job if a job exists in repo with the provided ID. Otherwise, return `None`.
- `update(job)`: If job with same ID exists in repo, replace with the supplied job and return the updated job. Otherwise do nothing and return `None`.
- `delete(job_id)`: If job with same ID exists, remove from repo and return deleted job, Otherwise do nothing and return `None`.