### PR TITLE
Add PATCH HTTP method to Job CRUD HTTP API, implementing JSON merge patch functionality

### DIFF
--- a/middleware/job/inmemory_repository.py
+++ b/middleware/job/inmemory_repository.py
@@ -10,7 +10,7 @@ class JobRepositoryMemory():
         return (job_id in self._jobs)
 
     def create(self, job):
-        job_id = job["id"]
+        job_id = job.get("id")
         if not self.exists(job_id):
             # Add job if it is not already in job list
             self._jobs[job_id] = job
@@ -25,7 +25,7 @@ class JobRepositoryMemory():
             return None
 
     def update(self, job):
-        job_id = job["id"]
+        job_id = job.get("id")
         if self.exists(job_id):
             # Replace job if already in job list
             self._jobs[job_id] = job

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ paramiko
 pytest
 flake8
 flask-restful
+json-merge-patch


### PR DESCRIPTION
Add PATCH HTTP method to Job CRUD HTTP API, implementing JSON merge patch functionality. Connects to #13.

PATCH (PARTIAL UPDATE) `/job/<job_id>`: Patch specified job using partial Job JSON provided in body (`Content-Type: application/merge-patch+json`)
  - [x] Returns  `404 - Not found` if no job ID provided in URL
  - [x] Returns  `404 - Not found` if no job exists with job ID provided in URL
  - [x] Returns `400 - Bad request` if request body is empty
  - [x] Returns `409 - Conflict` if job IDs in URL and request JSON don't match
  - [x] Returns `400 - Bad request` if body is not valid JSON
  - [x] Returns `400 - Bad request` if body JSON not valid partial Job JSON
    - We validate Job JSON resulting from applying patch to see if it is valid. This will always be the case at the moment as we only require presence of ID field and we don't allow this to be changed via PUT or PATCH. Therefore we cannot test this at the moment.
  - [x] Returns `200 - OK` with full updated job JSON in message body if job exists with specified ID
  - For simplicity, we are using the [JSON merge patch](http://erosb.github.io/post/json-patch-vs-merge-patch/) standard described in [RFC 7396](https://tools.ietf.org/html/rfc7396), which takes a subset of the target JSON structure as input (`Content-Type: application/merge-patch+json`). We are **not** using the [JSON patch](http://jsonpatch.com/) standard described in [RFC 6902](https://tools.ietf.org/html/rfc6902), which takes explicit edit operations as input (`Content-Type: application/json-patch+json`). While the explicit edit approach of JSON patch would provide maximum flexibility in the low-level Job API, we don't (yet) need this flexibility and using JSON merge patch means we can use similar validation as we do for the PUT action and don't need to work out how to validate patches (to e.g. ensure we don't allow Job ID to change).
- We are using the `json-merge-patch` [package](https://pypi.python.org/pypi/json-merge-patch/0.1) ([source](https://github.com/open-contracting/json-merge-patch)).

Note: While PATCH returns 400 if applying patch does not result in valid Job JSON, there is no way to test this at the moment as we reject patches earlier if the patch tries to change/delete the Job ID and the only criteria for a valid Job JSON is the presence of an ID field.
