### PR TITLE
Mock Blue job for frontend testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ git remote add azure $AZURE_REMOTE
 git push azure master
 ```
 
+Configure any un-committed files using ftp. The ftp address is available via `App Service > Properties` in Azure portal. An example ftp credentials are:
+
+```
+server address: ftps://waws-prod-am2-XXX.ftp.azurewebsites.windows.net
+user: Science-Gateway-Middleware\username
+```
+
 ## Testing
 
 Tests can be run via `python -m pytest`.

--- a/dev/dev
+++ b/dev/dev
@@ -25,9 +25,19 @@
 
 # TEST CASE 3
 
-# POST a new blue job and trigger RUN action
-http POST http://localhost:5000/api/jobs \
-  < ../resources/minimal_blue_test/job.json
+# # POST a new blue job and trigger RUN action
+# http POST http://localhost:5000/api/jobs \
+#   < ../resources/minimal_blue_test/job.json
+#
+# http POST http://localhost:5000/api/run/zfa6521e-a123-4a76-a04e-c367b6da169a\
+#   < ../resources/minimal_blue_test/job.json
 
-http POST http://localhost:5000/api/run/zfa6521e-a123-4a76-a04e-c367b6da169a\
-  < ../resources/minimal_blue_test/job.json
+
+# TEST CASE 4
+
+# POST a new *mock* blue job and trigger RUN action
+http POST http://localhost:5000/api/jobs \
+  < ../resources/mock_blue_simulation/job.json
+
+http POST http://localhost:5000/api/run/f17f97ea-ea74-468e-b637-b78f53f03b2d\
+  < ../resources/mock_blue_simulation/job.json

--- a/dev/dev_data
+++ b/dev/dev_data
@@ -2,5 +2,16 @@
 
 # INFO: requires httpie (brew install httpie)
 
-# GET trigger PROGRESS action
-http GET http://localhost:5000/api/data/zfa6521e-a123-4a76-a04e-c367b6da169a
+# # GET trigger DATA action
+# http GET http://localhost:5000/api/data/zfa6521e-a123-4a76-a04e-c367b6da169a
+
+
+
+
+# GET trigger DATA action
+
+# add job again (in case the middleware server has been restarted)
+http POST http://localhost:5000/api/jobs \
+  < ../resources/mock_blue_simulation/job.json
+
+http GET http://localhost:5000/api/data/f17f97ea-ea74-468e-b637-b78f53f03b2d

--- a/dev/dev_progress
+++ b/dev/dev_progress
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# INFO: requires httpie (brew install httpie)
+
+
+# GET trigger PROGRESS action
+
+# add job again (in case the middleware server has been restarted)
+http POST http://localhost:5000/api/jobs \
+  < ../resources/mock_blue_simulation/job.json
+
+http GET http://localhost:5000/api/progress/f17f97ea-ea74-468e-b637-b78f53f03b2d

--- a/middleware/job_information_manager.py
+++ b/middleware/job_information_manager.py
@@ -70,12 +70,13 @@ class job_information_manager():
         parameters = []
         for family in families:
             parameters.extend(family.parameters)
+        return parameters
 
     def _parameters_to_mako_dict(self, parameters):
         mako_dict = {}
         if parameters:
             for p in parameters:
-                mako_dict[p["name"]] = p["value"]
+                mako_dict[p.name] = p.value
         return mako_dict
 
     def _apply_patch(self, template_path, parameters, destination_path):

--- a/middleware/job_information_manager.py
+++ b/middleware/job_information_manager.py
@@ -231,7 +231,7 @@ class job_information_manager():
                     self.job.status = "submitted"
                     self.jobs.update(self.job)
 
-            if to_trigger.action == "DATA":
+            if to_trigger.action in ["DATA", "PROGRESS"]:
                 # convert stdout json string to json
                 out = json.loads(out)
 

--- a/middleware/ssh.py
+++ b/middleware/ssh.py
@@ -23,6 +23,7 @@ class ssh():
             os.makedirs(os.path.dirname('.logs/ssh.log'), exist_ok=True)
             paramiko.util.log_to_file('.logs/ssh.log')
         self.client = paramiko.SSHClient()
+        self.client.load_system_host_keys()
 
         if private_key_path:
             # use specified key
@@ -31,7 +32,6 @@ class ssh():
                                 pkey=k, look_for_keys=False)
         else:
             # look for system keys
-            self.client.load_system_host_keys()
             self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             self.client.connect(
                 hostname,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ Mako==1.0.7
 MarkupSafe==1.0
 marshmallow-sqlalchemy==0.13.1
 paramiko==2.2.1
-pathlib2==2.3.0
 py==1.4.34
 pyasn1==0.3.1
 pycparser==2.18

--- a/resources/cases/development_cases.json
+++ b/resources/cases/development_cases.json
@@ -1,30 +1,121 @@
 [{
-    "id": "af7fd241-e816-40e5-9a70-49598a452b7b",
-    "uri": null,
-    "label": null,
-    "thumbnail": null,
-    "description": "Test transfer of run script",
-    "job": {
-      "families": [],
-      "inputs": [],
-      "scripts": [{
-        "destination_path": "./",
-        "source_uri": "./resources/scripts/setup_job.sh",
-        "action": "RUN"
+  "id": "af7fd241-e816-40e5-9a70-49598a452b7b",
+  "uri": "https://science-gateway-middleware.azurewebsites.net/api/cases/af7fd241-e816-40e5-9a70-49598a452b7b",
+  "label": null,
+  "thumbnail": null,
+  "description": "Mock Blue case",
+  "job": {
+    "name": null,
+    "status": "new",
+    "scripts": [{
+        "source_uri": "./resources/mock_blue_simulation/pbs.sh",
+        "action": null,
+        "destination_path": "."
       },
       {
-        "destination_path": "./",
-        "source_uri": "./resources/scripts/pbs_script.sh",
-        "action": null
-      }],
-      "user": null,
-      "templates": [],
-      "name": null,
-      "description": null,
-      "creation_datetime": null,
-      "start_datetime": null,
-      "end_datetime": null,
-      "status": null
-    }
+        "source_uri": "./resources/mock_blue_simulation/mock_blue.py",
+        "action": null,
+        "destination_path": "."
+      },
+      {
+        "source_uri": "./resources/mock_blue_simulation/data.sh",
+        "action": "DATA",
+        "destination_path": "."
+      },
+      {
+        "source_uri": "./resources/mock_blue_simulation/run.sh",
+        "action": "RUN",
+        "destination_path": "."
+      },
+      {
+        "source_uri": "./resources/mock_blue_simulation/get_exec_host.sh",
+        "action": null,
+        "destination_path": "."
+      },
+      {
+        "source_uri": "./resources/mock_blue_simulation/cancel.sh",
+        "action": "CANCEL",
+        "destination_path": "."
+      },
+      {
+        "source_uri": "./resources/mock_blue_simulation/csv_to_data_json.py",
+        "action": null,
+        "destination_path": "."
+      }
+    ],
+    "id": "f17f97ea-ea74-468e-b637-b78f53f03b2d",
+    "backend_identifier": null,
+    "case": {
+      "id": "884cf075-a2a4-47bf-9d4d-844adc91946b",
+      "uri": null,
+      "description": "Mock blue job for testing",
+      "label": "mock_blue",
+      "thumbnail": null
+    },
+    "uri": "https://science-gateway-middleware.azurewebsites.net/api/jobs/f17f97ea-ea74-468e-b637-b78f53f03b2d",
+    "description": null,
+    "end_datetime": null,
+    "start_datetime": null,
+    "families": [{
+      "label": "Time step information",
+      "name": "model_properties",
+      "collapse": false,
+      "parameters": [{
+        "name": "initial_value",
+        "type": "slider",
+        "label": "Initial value",
+        "units": "kg",
+        "type_value": "float",
+        "min_value": "0.1",
+        "max_value": "10.0",
+        "value": "0.5",
+        "options": [],
+        "help": "",
+        "disabled": false
+      }, {
+        "name": "gradient",
+        "type": "slider",
+        "label": "Gradient",
+        "units": "kg/s",
+        "type_value": "float",
+        "min_value": "200",
+        "max_value": "400",
+        "value": "150",
+        "options": [],
+        "help": "",
+        "disabled": false
+      }, {
+        "name": "timestep_max",
+        "type": "slider",
+        "label": "Maximum timestep",
+        "units": "",
+        "type_value": "float",
+        "min_value": "10",
+        "max_value": "600",
+        "value": "300",
+        "options": [],
+        "help": "",
+        "disabled": false
+      }, {
+        "name": "dt",
+        "type": "slider",
+        "label": "Timestep magnitude",
+        "units": "s",
+        "type_value": "float",
+        "min_value": "0.001",
+        "max_value": "0.01",
+        "value": "0.005",
+        "options": [],
+        "help": "",
+        "disabled": false
+      }]
+    }],
+    "user": null,
+    "creation_datetime": "2017-08-21T09:56:01.621575+00:00",
+    "templates": [{
+      "source_uri": "./resources/mock_blue_simulation/Blue.nml",
+      "destination_path": "."
+    }],
+    "inputs": []
   }
-]
+}]

--- a/resources/cases/development_cases.json
+++ b/resources/cases/development_cases.json
@@ -23,6 +23,11 @@
         "destination_path": "."
       },
       {
+        "source_uri": "./resources/mock_blue_simulation/progress.sh",
+        "action": "PROGRESS",
+        "destination_path": "."
+      },
+      {
         "source_uri": "./resources/mock_blue_simulation/run.sh",
         "action": "RUN",
         "destination_path": "."

--- a/resources/mock_blue_simulation/Blue.nml
+++ b/resources/mock_blue_simulation/Blue.nml
@@ -1,0 +1,8 @@
+&MODEL_PROPERTIES
+!-------------------------------------------------------------------------------------------------------------------------------
+! Time step factor multipliers
+  initial_value    = ${parameters['initial_value']}
+  gradient   = ${parameters['gradient']}
+  timestep_max = ${parameters['timestep_max']}
+  dt = ${parameters['dt']}
+!--------------------------------------------------------------------------------------------------------------------------------

--- a/resources/mock_blue_simulation/cancel.sh
+++ b/resources/mock_blue_simulation/cancel.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+PBS_JOB_ID=$(cat pbs_job_id)
+qdel $PBS_JOB_ID

--- a/resources/mock_blue_simulation/csv_to_data_json.py
+++ b/resources/mock_blue_simulation/csv_to_data_json.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+from __future__ import print_function  # for python 2 compatability
+
+import csv
+import json
+
+
+def csv_to_data_json(fname, data_required=None):
+
+    with open(fname, 'r') as f:
+        d_reader = csv.DictReader(f)
+        headers = d_reader.fieldnames
+
+        columns_to_process = headers  # default to processing all csv columns
+        column_labels = headers
+        if data_required:
+            columns_to_process = []
+            column_labels = []
+            for object_ in data_required:
+                columns_to_process.append(object_['csv_variable'])
+                column_labels.append(object_['label'])
+
+        output = {
+            "keys": columns_to_process,
+            "labels": column_labels
+        }
+
+        # prepare data lists
+        for name in columns_to_process:
+            output[name] = []
+
+        # populate data lists
+        for line in d_reader:
+            for name in columns_to_process:
+                output[name].append(float(line[str(name)]))
+
+        return {"data": output}
+
+
+data_required = [
+    {
+        "csv_variable": "Time(s)",
+        "label": "Time",
+        "units": "s"
+    },
+    {
+        "csv_variable": "linear",
+        "label": "Linear quantity",
+        "units": "kg"
+    },
+    {
+        "csv_variable": "noisy",
+        "label": "Random quantity",
+        "units": "L"
+    }
+]
+
+data_object = csv_to_data_json(
+    "output.csv",
+    data_required=data_required)
+
+print(json.dumps(data_object))  # print to stdout
+
+
+# The above code uses csv and json from the standard library
+# pandas takes too long to load on cx1
+# test this for yourself using the line below
+# module load anaconda3; python -c "import pandas"
+
+# The above code could be implemented concisely in pandas using
+#
+# import pandas as pd
+# import json
+# csv_variables_to_keep = ["Time(s)", "FLUID_VOLUME"]
+# label_strings = ["Time (s)", "Fluid volume (-)"]
+#
+# df = pd.DataFrame(
+#     pd.read_csv("aeration.csv", sep=",", header=0, index_col=False))
+# df_output = df[csv_variables_to_keep]
+#
+# data_object = {"keys": csv_variables_to_keep, "labels": label_strings}
+# for csv_variable in csv_variables_to_keep:
+#     data_object[csv_variable] = df[csv_variable].values.tolist()
+# print(json.dumps({"data": data_object}))

--- a/resources/mock_blue_simulation/csv_to_progress_json.py
+++ b/resources/mock_blue_simulation/csv_to_progress_json.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# return job progress, example output is
+
+# {
+#   "progress": {
+#     "range_min": 0,
+#     "range_max": 100,
+#     "value": 0.0037375,
+#     "units": "%"
+#   }
+# }
+
+from __future__ import print_function  # for python 2 compatability
+
+from collections import deque
+import csv
+import json
+import re
+
+
+def get_reference_value():
+
+    with open('Blue.nml', 'r') as f:
+        parameter_lines = f.readlines()
+
+    for line in parameter_lines:
+        timestep_max_input = re.search(r'timestep_max\s+=\s+(\S+)', line)
+        if timestep_max_input:
+            timestep_max = float(timestep_max_input.group(1))
+
+    return timestep_max
+
+
+def get_last_row(fname):
+    with open(fname, 'r') as f:
+        try:
+            lastrow = deque(csv.reader(f), 1)[0]
+        except IndexError:  # empty file
+            lastrow = None
+        return lastrow
+
+
+def csv_to_progress_json(fname):
+    with open(fname, 'r') as f:
+
+        output = {
+            "range_min": 0,
+            "range_max": 100,
+            "value": 0,
+            "units": "%"
+        }
+
+        d_reader = csv.DictReader(f)
+        headers = d_reader.fieldnames
+
+        try:
+            index = headers.index('timestep')
+        except:
+            # csv file is empty
+            return {"progress": output}
+
+        last_row = get_last_row(fname)
+        latest_value = float(last_row[index])
+
+        reference_value = get_reference_value()
+        progress = latest_value/reference_value
+        output["value"] = progress
+
+        return {"progress": output}
+
+
+progress_object = csv_to_progress_json("output.csv")
+
+print(json.dumps(progress_object))  # print to stdout

--- a/resources/mock_blue_simulation/data.sh
+++ b/resources/mock_blue_simulation/data.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# create a file named `pbs_job_identifier`
+# which contains the pbs id (example: "5309476.cx1b")
+# use `tee` to retain stdout
+
+PBS_JOB_ID=$(cat pbs_job_id)
+EXEC_HOST=$(bash get_exec_host.sh)
+TMPDIR="/tmp/pbs.$PBS_JOB_ID"
+
+ssh $EXEC_HOST "cd $TMPDIR && python csv_to_data_json.py"

--- a/resources/mock_blue_simulation/get_exec_host.sh
+++ b/resources/mock_blue_simulation/get_exec_host.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+PBS_JOB_ID=$(cat pbs_job_id)
+
+# Example: parses "    exec_host = cx1-50-3-2/13 " into "cx1-50-3-2"
+qstat -f $PBS_JOB_ID | grep 'exec_host' | awk -F= '{print $2}' | awk -F/ '{print $1}' | tr -d ' '

--- a/resources/mock_blue_simulation/job.json
+++ b/resources/mock_blue_simulation/job.json
@@ -1,0 +1,114 @@
+{
+  "name": null,
+  "status": "new",
+  "scripts": [{
+      "source_uri": "./resources/mock_blue_simulation/pbs.sh",
+      "action": null,
+      "destination_path": "."
+    },
+    {
+      "source_uri": "./resources/mock_blue_simulation/mock_blue.py",
+      "action": null,
+      "destination_path": "."
+    },
+    {
+      "source_uri": "./resources/mock_blue_simulation/data.sh",
+      "action": "DATA",
+      "destination_path": "."
+    },
+    {
+      "source_uri": "./resources/mock_blue_simulation/run.sh",
+      "action": "RUN",
+      "destination_path": "."
+    },
+    {
+      "source_uri": "./resources/mock_blue_simulation/get_exec_host.sh",
+      "action": null,
+      "destination_path": "."
+    },
+    {
+      "source_uri": "./resources/mock_blue_simulation/cancel.sh",
+      "action": "CANCEL",
+      "destination_path": "."
+    },
+    {
+      "source_uri": "./resources/mock_blue_simulation/csv_to_data_json.py",
+      "action": null,
+      "destination_path": "."
+    }
+  ],
+  "id": "f17f97ea-ea74-468e-b637-b78f53f03b2d",
+  "backend_identifier": null,
+  "case": {
+    "id": "884cf075-a2a4-47bf-9d4d-844adc91946b",
+    "uri": null,
+    "description": "Mock blue job for testing",
+    "label": "mock_blue",
+    "thumbnail": null
+  },
+  "uri": "https://science-gateway-middleware.azurewebsites.net/api/jobs/f17f97ea-ea74-468e-b637-b78f53f03b2d",
+  "description": null,
+  "end_datetime": null,
+  "start_datetime": null,
+  "families": [{
+    "label": "Time step information",
+    "name": "model_properties",
+    "collapse": false,
+    "parameters": [{
+      "name": "initial_value",
+      "type": "slider",
+      "label": "Initial value",
+      "units": "kg",
+      "type_value": "float",
+      "min_value": "0.1",
+      "max_value": "10.0",
+      "value": "0.5",
+      "options": [],
+      "help": "",
+      "disabled": false
+    }, {
+      "name": "gradient",
+      "type": "slider",
+      "label": "Gradient",
+      "units": "kg/s",
+      "type_value": "float",
+      "min_value": "200",
+      "max_value": "400",
+      "value": "150",
+      "options": [],
+      "help": "",
+      "disabled": false
+    }, {
+      "name": "timestep_max",
+      "type": "slider",
+      "label": "Maximum timestep",
+      "units": "",
+      "type_value": "float",
+      "min_value": "10",
+      "max_value": "600",
+      "value": "300",
+      "options": [],
+      "help": "",
+      "disabled": false
+    }, {
+      "name": "dt",
+      "type": "slider",
+      "label": "Timestep magnitude",
+      "units": "s",
+      "type_value": "float",
+      "min_value": "0.001",
+      "max_value": "0.01",
+      "value": "0.005",
+      "options": [],
+      "help": "",
+      "disabled": false
+    }]
+  }],
+  "user": null,
+  "creation_datetime": "2017-08-21T09:56:01.621575+00:00",
+  "templates": [{
+    "source_uri": "./resources/mock_blue_simulation/Blue.nml",
+    "destination_path": "."
+  }],
+  "inputs": []
+}

--- a/resources/mock_blue_simulation/job.json
+++ b/resources/mock_blue_simulation/job.json
@@ -22,6 +22,11 @@
       "destination_path": "."
     },
     {
+      "source_uri": "./resources/mock_blue_simulation/progress.sh",
+      "action": "PROGRESS",
+      "destination_path": "."
+    },
+    {
       "source_uri": "./resources/mock_blue_simulation/get_exec_host.sh",
       "action": null,
       "destination_path": "."
@@ -33,6 +38,11 @@
     },
     {
       "source_uri": "./resources/mock_blue_simulation/csv_to_data_json.py",
+      "action": null,
+      "destination_path": "."
+    },
+    {
+      "source_uri": "./resources/mock_blue_simulation/csv_to_progress_json.py",
       "action": null,
       "destination_path": "."
     }

--- a/resources/mock_blue_simulation/mock_blue.py
+++ b/resources/mock_blue_simulation/mock_blue.py
@@ -91,10 +91,10 @@ def stdout(timestep):
 # and write to this csv file
 with open('output.csv', 'w') as csv_file:
     writer = csv.writer(csv_file)
-    writer.writerow(['Time(s)', 'linear', 'noisy'])
+    writer.writerow(['Time(s)', 'timestep', 'linear', 'noisy'])
     for timestep in range(timestep_max):
         stdout(timestep)
         linear = model_linear(timestep)
         noisy = model_noisy(timestep)
-        writer.writerow([time(timestep), linear, noisy])
+        writer.writerow([time(timestep), timestep, linear, noisy])
         delay()

--- a/resources/mock_blue_simulation/mock_blue.py
+++ b/resources/mock_blue_simulation/mock_blue.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+import csv
+
+from time import sleep
+import random
+import re
+
+# example parameter settings
+# (for testing with hardcoded parameters)
+
+# timestep_max = 300
+# dt = 1e-4
+#
+# initial_value = 10
+# gradient = 400
+
+
+# read parameters from mock input file
+# for Blue, the input file is a fortran name list
+
+def info(name, value):
+    print('Loading parameter: {}={}'.format(name, value))
+
+with open('Blue.nml', 'r') as f:
+    parameter_lines = f.readlines()
+
+for line in parameter_lines:
+
+    initial_value_input = re.search(r'initial_value\s+=\s+(\S+)', line)
+    gradient_input = re.search(r'gradient\s+=\s+(\S+)', line)
+    timestep_max_input = re.search(r'timestep_max\s+=\s+(\S+)', line)
+    dt_input = re.search(r'dt\s+=\s+(\S+)', line)
+
+    if initial_value_input:
+        initial_value = float(initial_value_input.group(1))
+        info('initial_value', initial_value)
+    if gradient_input:
+        gradient = float(gradient_input.group(1))
+        info('gradient', gradient)
+    if timestep_max_input:
+        timestep_max = int(timestep_max_input.group(1))
+        info('timestep_max', timestep_max)
+    if dt_input:
+        dt = float(dt_input.group(1))
+        info('dt', dt)
+
+
+def time(timestep):
+    return timestep * dt
+
+
+def model_linear(timestep, initial_value=initial_value, gradient=gradient):
+    return time(timestep) * gradient + initial_value
+
+
+def model_noisy(time):
+    return random.random()
+
+
+def delay():
+    sleep(1)
+
+
+statement = """
+ *** (C) BLUE MMXVI, release 11.2. All Rights Reserved.
+
+
+ ... Reading input parameters ...
+
+ ... Entering initial setup ...
+
+ ... Entering timestep loop ...
+
+ ... Setting initial pressure ...
+ """
+
+info = """
+*** TIME INDEX:        {:5d}           |             REAL TIME:  {:10.4f}    ***
+----------------------------------------------------------------------------------
+max(|div(V)|):                                                          {:10.4f}
+----------------------------------------------------------------------------------
+"""
+
+
+def stdout(timestep):
+    time = timestep * dt
+    print(info.format(timestep, time, random.random())+"\n")
+
+
+# and write to this csv file
+with open('output.csv', 'w') as csv_file:
+    writer = csv.writer(csv_file)
+    writer.writerow(['Time(s)', 'linear', 'noisy'])
+    for timestep in range(timestep_max):
+        stdout(timestep)
+        linear = model_linear(timestep)
+        noisy = model_noisy(timestep)
+        writer.writerow([time(timestep), linear, noisy])
+        delay()

--- a/resources/mock_blue_simulation/pbs.sh
+++ b/resources/mock_blue_simulation/pbs.sh
@@ -15,6 +15,7 @@ mkdir -p $TMPDIR
 cp $PBS_O_WORKDIR/mock_blue.py $TMPDIR
 cp $PBS_O_WORKDIR/Blue.nml $TMPDIR
 cp $PBS_O_WORKDIR/csv_to_data_json.py $TMPDIR
+cp $PBS_O_WORKDIR/csv_to_progress_json.py $TMPDIR
 
 cd $TMPDIR
 

--- a/resources/mock_blue_simulation/pbs.sh
+++ b/resources/mock_blue_simulation/pbs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#PBS -j oe
+#PBS -o "TEST.out"
+
+echo "Start PBS"
+
+set -vx
+
+# emulate running in TMPDIR as per Imperial College cx1
+TMPDIR="/tmp/pbs.$PBS_JOBID"
+
+echo $TMPDIR
+
+mkdir -p $TMPDIR
+cp $PBS_O_WORKDIR/mock_blue.py $TMPDIR
+cp $PBS_O_WORKDIR/Blue.nml $TMPDIR
+cp $PBS_O_WORKDIR/csv_to_data_json.py $TMPDIR
+
+cd $TMPDIR
+
+python mock_blue.py  # emulate `mpiexec ./$PROGRAM`
+
+cp $TMPDIR/*.csv $PBS_O_WORKDIR
+
+echo "End PBS"

--- a/resources/mock_blue_simulation/progress.sh
+++ b/resources/mock_blue_simulation/progress.sh
@@ -4,4 +4,4 @@ PBS_JOB_ID=$(cat pbs_job_id)
 EXEC_HOST=$(bash get_exec_host.sh)
 TMPDIR="/tmp/pbs.$PBS_JOB_ID"
 
-ssh $EXEC_HOST "cd $TMPDIR && python csv_to_data_json.py"
+ssh $EXEC_HOST "cd $TMPDIR && python csv_to_progress_json.py"

--- a/resources/mock_blue_simulation/run.sh
+++ b/resources/mock_blue_simulation/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# create a file named `pbs_job_id`
+# which contains the pbs id (example: "5309476.cx1b")
+# use `tee` to retain stdout
+qsub -k oe pbs.sh | tee pbs_job_id
+# qsub pbs.sh | tee pbs_job_id

--- a/tests/jim/test_job_information_manager.py
+++ b/tests/jim/test_job_information_manager.py
@@ -5,7 +5,7 @@ from middleware.job_information_manager import job_information_manager as JIM
 from middleware.ssh import ssh
 from tests.job.new_jobs import new_job5
 from instance.config import *
-from middleware.job.schema import Template, job_to_json
+from middleware.job.schema import Parameter, Template, job_to_json
 
 
 def abstract_getting_secrets():
@@ -78,16 +78,16 @@ class TestJIM(object):
         manager = JIM(job)
 
         # create dict objects for parameters and templates
-        job_json = job_to_json(job)
-        families = job_json.get("families")
-        parameters = families[0].get("parameters")
+
+        families = job.families
+        parameters = families[0].parameters
         parameter = parameters[0]  # choose first parameter
 
-        templates = job_json.get("templates")
+        templates = job.templates
         template = templates[0]  # choose first template
 
-        template_path = template.get("source_uri")
-        in_parameter_value = parameter.get("value")
+        template_path = template.source_uri
+        in_parameter_value = parameter.value
 
         template_filename = os.path.basename(template_path)
         destination_path = os.path.join(tmpdir.strpath, template_filename)
@@ -163,9 +163,8 @@ class TestJIM(object):
     @mock.patch('middleware.job_information_manager.job_information_manager.'
                 '_run_remote_script', side_effect=mock_run_remote)
     def test_trigger_action_script_valid_verbs(self, mock_run):
-        # Test that the 4 verbs work
-        # TODO test DATA
-        for verb in ['RUN', 'SETUP', 'CANCEL', 'PROGRESS']:
+        # TODO test DATA and PROGRESS
+        for verb in ['RUN', 'SETUP', 'CANCEL']:
 
             job = new_job5()
             manager = JIM(job)


### PR DESCRIPTION
This adds a mock Blue test in `resources/mock_blue_simulation`

To use:

*  the following must exist in `instance/config`

```
SSH_USR = "vm-admin"
SSH_HOSTNAME = "science-gateway-cluster.westeurope.cloudapp.azure.com"
SSH_PORT = 22
SIM_ROOT = "/work/vm-admin/Blue"
PRIVATE_KEY_PATH = "keys/azure_development"
```

* the private RSA key for the Azure "cluster" VM must exist and be named as `keys/azure_development`

* In `config/test.py`, set `LOAD_DEVELOPMENT_CASES = True` to that the mock case is loaded. The mock case lives in `resources/cases/development_cases.json`


Example cURL commands for demonstrating this are:

* POST a new *mock* blue job and trigger the RUN action
```
http POST http://localhost:5000/api/jobs \
  < ../resources/mock_blue_simulation/job.json

http POST http://localhost:5000/api/run/f17f97ea-ea74-468e-b637-b78f53f03b2d\
  < ../resources/mock_blue_simulation/job.json
```

* GET latest data json

```
http GET http://localhost:5000/api/data/f17f97ea-ea74-468e-b637-b78f53f03b2d
```

* GET latest progress json

```
http GET http://localhost:5000/api/progress/f17f97ea-ea74-468e-b637-b78f53f03b2d
```


