### PR TITLE
Change all http calls to https

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -10,7 +10,7 @@ URI_STEMS = {'jobs': '/api/jobs',
              'cases': '/api/cases',
              'thumbnails': '/assets/thumbnails'}
 
-MIDDLEWARE_URL = "http://science-gateway-middleware.azurewebsites.net"
+MIDDLEWARE_URL = "https://science-gateway-middleware.azurewebsites.net"
 # MIDDLEWARE_URL = "http://localhost:5000"
 
 MIDDLEWARE_ONLY_JOB_FIELDS = [

--- a/resources/mock_product_changeover/job.json
+++ b/resources/mock_product_changeover/job.json
@@ -61,7 +61,7 @@
     "label": "Product Changeover",
     "thumbnail": "https://sgmiddleware.blob.core.windows.net/blue/thumbnails/product_changeover.png"
   },
-  "uri": "http://science-gateway-middleware-dev/api/jobs/3957553c-486a-46ed-87c2-3d67f58e7cbf",
+  "uri": "https://science-gateway-middleware-dev/api/jobs/3957553c-486a-46ed-87c2-3d67f58e7cbf",
   "families": [{
       "label": "Viscosities",
       "name": "viscosity_properties",

--- a/resources/mock_stirred_tank/job.json
+++ b/resources/mock_stirred_tank/job.json
@@ -61,7 +61,7 @@
     "label": "Stirred Tank",
     "thumbnail": "https://sgmiddleware.blob.core.windows.net/blue/thumbnails/stirred_tank.png"
   },
-  "uri": "http://science-gateway-middleware-dev/api/jobs/96ef005e-e4a6-4cb7-a39a-ca269cca9430",
+  "uri": "https://science-gateway-middleware-dev/api/jobs/96ef005e-e4a6-4cb7-a39a-ca269cca9430",
   "families": [
     {
         "label": "Tank",

--- a/resources/mock_stratified_flow/job.json
+++ b/resources/mock_stratified_flow/job.json
@@ -61,7 +61,7 @@
     "label": "Stirred Tank",
     "thumbnail": "https://sgmiddleware.blob.core.windows.net/blue/thumbnails/stirred_tank.png"
   },
-  "uri": "http://science-gateway-middleware-dev/api/jobs/96ef005e-e4a6-4cb7-a39a-ca269cca9430",
+  "uri": "https://science-gateway-middleware-dev/api/jobs/96ef005e-e4a6-4cb7-a39a-ca269cca9430",
   "families": [
     {
         "label": "Tank",

--- a/resources/prerun_product_changeover/job.json
+++ b/resources/prerun_product_changeover/job.json
@@ -4,9 +4,9 @@
   "user": "lrmason",
   "description": "A prerun product changeover simulation",
   "status": "Complete",
-  "creation_datetime": "2017-09-03T09:56:01.621575+00:00",
-  "start_datetime": "2017-09-05T09:56:01.621575+00:00",
-  "end_datetime": "2017-09-10T09:56:01.621575+00:00",
+  "creation_datetime": "2017-11-03T09:56:01.621575+00:00",
+  "start_datetime": "2017-11-05T09:56:01.621575+00:00",
+  "end_datetime": "2017-11-10T09:56:01.621575+00:00",
   "scripts": [{
       "source_uri": "./resources/prerun_product_changeover/pbs.sh",
       "action": null,
@@ -61,7 +61,7 @@
     "label": "Product Changeover",
     "thumbnail": "https://sgmiddleware.blob.core.windows.net/blue/thumbnails/product_changeover.png"
   },
-  "uri": "http://science-gateway-middleware-dev/api/jobs/3957553c-486a-46ed-87c2-3d67f58e7cbf",
+  "uri": "https://science-gateway-middleware-dev/api/jobs/3957553c-486a-46ed-87c2-3d67f58e7cbf",
   "families": [{
       "label": "Viscosities",
       "name": "viscosity_properties",

--- a/resources/prerun_stirred_tank/job.json
+++ b/resources/prerun_stirred_tank/job.json
@@ -4,9 +4,9 @@
   "user": "lrmason",
   "description": "Stirred tank example.",
   "status": "Complete",
-  "creation_datetime": "2017-09-01T09:56:01.621575+00:00",
-  "start_datetime": "2017-09-08T09:56:01.621575+00:00",
-  "end_datetime": "2017-09-11T09:56:01.621575+00:00",
+  "creation_datetime": "2017-11-01T09:56:01.621575+00:00",
+  "start_datetime": "2017-11-08T09:56:01.621575+00:00",
+  "end_datetime": "2017-11-11T09:56:01.621575+00:00",
   "scripts": [{
       "source_uri": "./resources/prerun_stirred_tank/pbs.sh",
       "action": null,
@@ -61,7 +61,7 @@
     "label": "Stirred Tank",
     "thumbnail": "https://sgmiddleware.blob.core.windows.net/blue/thumbnails/stirred_tank.png"
   },
-  "uri": "http://science-gateway-middleware-dev/api/jobs/96ef005e-e4a6-4cb7-a39a-ca269cca9430",
+  "uri": "https://science-gateway-middleware-dev/api/jobs/96ef005e-e4a6-4cb7-a39a-ca269cca9430",
   "families": [
     {
         "label": "Tank",

--- a/resources/prerun_stratified_flow/job.json
+++ b/resources/prerun_stratified_flow/job.json
@@ -4,9 +4,9 @@
   "user": "lrmason",
   "description": "A prerun stratified flow simulation",
   "status": "Complete",
-  "creation_datetime": "2017-09-06T09:56:01.621575+00:00",
-  "start_datetime": "2017-09-06T09:56:01.621575+00:00",
-  "end_datetime": "2017-09-06T09:56:01.621575+00:00",
+  "creation_datetime": "2017-11-06T09:56:01.621575+00:00",
+  "start_datetime": "2017-11-06T09:56:01.621575+00:00",
+  "end_datetime": "2017-11-06T09:56:01.621575+00:00",
   "scripts": [{
       "source_uri": "./resources/prerun_stratified_flow/pbs.sh",
       "action": null,
@@ -59,9 +59,9 @@
     "uri": null,
     "description": "Here we describe the actual Stratified Flow case.",
     "label": "Stratified Flow",
-    "thumbnail": "http://sgmiddleware.blob.core.windows.net/blue/thumbnails/stratified_flow.png"
+    "thumbnail": "https://sgmiddleware.blob.core.windows.net/blue/thumbnails/stratified_flow.png"
   },
-  "uri": "http://science-gateway-middleware-dev/api/jobs/19fcb331-6759-4619-bc75-bc7b0588b72f",
+  "uri": "https://science-gateway-middleware-dev/api/jobs/19fcb331-6759-4619-bc75-bc7b0588b72f",
   "families": [{
       "label": "Interface settings",
       "name": "interface_settings",


### PR DESCRIPTION
Now that we are using SSL/https we need all external links (mock job storage) to call via https.